### PR TITLE
Yarn-pnp: Attach to session and hoist filesystem overrides

### DIFF
--- a/internal/project/autoimport.go
+++ b/internal/project/autoimport.go
@@ -11,7 +11,6 @@ import (
 	"github.com/microsoft/typescript-go/internal/pnp"
 	"github.com/microsoft/typescript-go/internal/tspath"
 	"github.com/microsoft/typescript-go/internal/vfs"
-	"github.com/microsoft/typescript-go/internal/vfs/pnpvfs"
 )
 
 type autoImportBuilderFS struct {
@@ -83,14 +82,10 @@ func newAutoImportRegistryCloneHost(
 	projectCollection *ProjectCollection,
 	parseCache *ParseCache,
 	snapshotFSBuilder *snapshotFSBuilder,
+	pnpApi *pnp.PnpApi,
 	currentDirectory string,
 	toPath func(fileName string) tspath.Path,
 ) *autoImportRegistryCloneHost {
-	pnpApi := pnp.InitPnpApi(snapshotFSBuilder.fs, currentDirectory)
-	if pnpApi != nil {
-		snapshotFSBuilder.fs = pnpvfs.From(snapshotFSBuilder.fs)
-	}
-
 	return &autoImportRegistryCloneHost{
 		projectCollection: projectCollection,
 		parseCache:        parseCache,

--- a/internal/project/compilerhost.go
+++ b/internal/project/compilerhost.go
@@ -9,7 +9,6 @@ import (
 	"github.com/microsoft/typescript-go/internal/tsoptions"
 	"github.com/microsoft/typescript-go/internal/tspath"
 	"github.com/microsoft/typescript-go/internal/vfs"
-	"github.com/microsoft/typescript-go/internal/vfs/pnpvfs"
 )
 
 var _ compiler.CompilerHost = (*compilerHost)(nil)
@@ -34,17 +33,12 @@ func newCompilerHost(
 	builder *ProjectCollectionBuilder,
 	logger *logging.LogTree,
 ) *compilerHost {
-	pnpApi := pnp.InitPnpApi(builder.fs.fs, currentDirectory)
-	if pnpApi != nil {
-		builder.fs.fs = pnpvfs.From(builder.fs.fs)
-	}
-
 	return &compilerHost{
 		configFilePath:   project.configFilePath,
 		currentDirectory: currentDirectory,
 		sessionOptions:   builder.sessionOptions,
 
-		pnpApi:   pnpApi,
+		pnpApi:   builder.pnpApi,
 		sourceFS: newSourceFS(true, builder.fs, builder.toPath),
 
 		project: project,

--- a/internal/project/projectcollectionbuilder.go
+++ b/internal/project/projectcollectionbuilder.go
@@ -35,6 +35,7 @@ type ProjectCollectionBuilder struct {
 
 	ctx                                context.Context
 	fs                                 *snapshotFSBuilder
+	pnpApi                             *pnp.PnpApi
 	base                               *ProjectCollection
 	compilerOptionsForInferredProjects *core.CompilerOptions
 	configFileRegistryBuilder          *configFileRegistryBuilder
@@ -56,12 +57,12 @@ func newProjectCollectionBuilder(
 	ctx context.Context,
 	newSnapshotID uint64,
 	fs *snapshotFSBuilder,
+	pnpApi *pnp.PnpApi,
 	oldProjectCollection *ProjectCollection,
 	oldConfigFileRegistry *ConfigFileRegistry,
 	oldAPIOpenedProjects map[tspath.Path]struct{},
 	compilerOptionsForInferredProjects *core.CompilerOptions,
 	sessionOptions *SessionOptions,
-	pnpApi *pnp.PnpApi,
 	customConfigFileName string,
 	parseCache *ParseCache,
 	extendedConfigCache *ExtendedConfigCache,
@@ -70,6 +71,7 @@ func newProjectCollectionBuilder(
 	return &ProjectCollectionBuilder{
 		ctx:                                ctx,
 		fs:                                 fs,
+		pnpApi:                             pnpApi,
 		toPath:                             fs.toPath,
 		compilerOptionsForInferredProjects: compilerOptionsForInferredProjects,
 		sessionOptions:                     sessionOptions,

--- a/internal/project/session.go
+++ b/internal/project/session.go
@@ -87,6 +87,7 @@ type Session struct {
 	logger        logging.Logger
 	npmExecutor   ata.NpmExecutor
 	fs            *overlayFS
+	pnpApi        *pnp.PnpApi
 
 	// parseCache is the ref-counted cache of source files used when
 	// creating programs during snapshot cloning.
@@ -181,6 +182,7 @@ func NewSession(init *SessionInit) *Session {
 		logger:              init.Logger,
 		npmExecutor:         init.NpmExecutor,
 		fs:                  overlayFS,
+		pnpApi:              init.PnpApi,
 		parseCache:          parseCache,
 		extendedConfigCache: extendedConfigCache,
 		programCounter:      &programCounter{},
@@ -243,7 +245,7 @@ func (s *Session) GetCurrentDirectory() string {
 
 // PnpApi implements module.ResolutionHost
 func (s *Session) PnpApi() *pnp.PnpApi {
-	return s.snapshot.PnpApi()
+	return s.pnpApi
 }
 
 // Gets copy of current configuration

--- a/internal/project/snapshot.go
+++ b/internal/project/snapshot.go
@@ -21,7 +21,6 @@ import (
 	"github.com/microsoft/typescript-go/internal/project/logging"
 	"github.com/microsoft/typescript-go/internal/sourcemap"
 	"github.com/microsoft/typescript-go/internal/tspath"
-	"github.com/microsoft/typescript-go/internal/vfs/pnpvfs"
 	"github.com/microsoft/typescript-go/internal/vfs/vfsmatch"
 )
 
@@ -65,10 +64,6 @@ func NewSnapshot(
 	toPath func(fileName string) tspath.Path,
 	pnpApi *pnp.PnpApi,
 ) *Snapshot {
-	if pnpApi != nil {
-		fs.fs = pnpvfs.From(fs.fs)
-	}
-
 	s := &Snapshot{
 		id: id,
 
@@ -80,11 +75,10 @@ func NewSnapshot(
 		ProjectCollection:                  &ProjectCollection{toPath: toPath},
 		compilerOptionsForInferredProjects: compilerOptionsForInferredProjects,
 
-		pnpApi: pnpApi,
-
 		userPreferences:  userPreferences,
 		AutoImports:      autoImports,
 		autoImportsWatch: autoImportsWatch,
+		pnpApi:           pnpApi,
 	}
 	s.refCount.Store(1)
 	s.converters = lsconv.NewConverters(s.sessionOptions.PositionEncoding, s.LSPLineMap)
@@ -339,12 +333,12 @@ func (s *Snapshot) Clone(ctx context.Context, change SnapshotChange, overlays ma
 		ctx,
 		newSnapshotID,
 		fs,
+		session.pnpApi,
 		s.ProjectCollection,
 		s.ConfigFileRegistry,
 		s.ProjectCollection.apiOpenedProjects,
 		compilerOptionsForInferredProjects,
 		s.sessionOptions,
-		s.pnpApi,
 		customConfigFileName,
 		session.parseCache,
 		session.extendedConfigCache,
@@ -429,6 +423,7 @@ func (s *Snapshot) Clone(ctx context.Context, change SnapshotChange, overlays ma
 		projectCollection,
 		session.parseCache,
 		fs,
+		session.pnpApi,
 		s.sessionOptions.CurrentDirectory,
 		s.toPath,
 	)
@@ -469,7 +464,7 @@ func (s *Snapshot) Clone(ctx context.Context, change SnapshotChange, overlays ma
 		autoImports,
 		autoImportsWatch,
 		s.toPath,
-		s.pnpApi,
+		session.pnpApi,
 	)
 	newSnapshot.parentId = s.id
 	newSnapshot.ProjectCollection = projectCollection


### PR DESCRIPTION
## Overview
This diff removes some of the intermediary filesystem overrides and hoists those to the Go entrypoints for simplicity. We still have to plumb the pnpApi down so that it can be reached during module resolution. This is now done by attaching pnpApi to "session" instead of arbitarily passing it as an argument in various places, except in the boundary cases where session is not passed further, where we then pass the pnpApi itself from the session.

In general this should simplify the amount of touch points yarn pnp has with typescript-go, reducing merge conflicts or breakages.

Additionally, the reuse of entrypoint pnpApi initializations and removal of extra calls to "pnp.InitPnpApi" fixes a panic with the following stack trace when running the typescript-go binary in --api mode:

```
panic: CallbackFS: readFile called before connection set

goroutine 1 [running]:
github.com/microsoft/typescript-go/internal/api.(*callbackFS).ReadFile(0x1b098cc92a40, {0x1b098733f4f0, 0x42})
        /Users/guyllian.gomez/dev/typescript-go/internal/api/callbackfs.go:108 +0x150
github.com/microsoft/typescript-go/internal/pnp.parseManifestFromPath({0x10213a340, 0x1b098cc92a40}, {0x16f1466ef, 0x33})
        /Users/guyllian.gomez/dev/typescript-go/internal/pnp/manifestparser.go:83 +0x68
github.com/microsoft/typescript-go/internal/pnp.(*PnpApi).findClosestPnpManifest(0x1b098730f140)
        /Users/guyllian.gomez/dev/typescript-go/internal/pnp/pnpapi.go:163 +0xfc
github.com/microsoft/typescript-go/internal/pnp.InitPnpApi({0x10213a340, 0x1b098cc92a40}, {0x16f1466ef, 0x33})
        /Users/guyllian.gomez/dev/typescript-go/internal/pnp/pnp.go:12 +0x78
github.com/microsoft/typescript-go/internal/project.NewSnapshot(_, _, _, _, _, {{{0x0, 0x4, 0x4, {0x1015a5fb8, 0x1}, ...}, ...}, ...}, ...)
        /Users/guyllian.gomez/dev/typescript-go/internal/project/snapshot.go:67 +0x44
github.com/microsoft/typescript-go/internal/project.NewSession(0x1b09894abd00)
        /Users/guyllian.gomez/dev/typescript-go/internal/project/session.go:188 +0x38c
github.com/microsoft/typescript-go/internal/api.(*StdioServer).Run(0x1b09894abe08, {0x1021328b8, 0x1b0986426a80})
        /Users/guyllian.gomez/dev/typescript-go/internal/api/server.go:85 +0x350
main.runAPI({0x1b098629e200, 0x4, 0x4})
        /Users/guyllian.gomez/dev/typescript-go/cmd/tsgo/api.go:54 +0x30c
main.runMain()
        /Users/guyllian.gomez/dev/typescript-go/cmd/tsgo/main.go:20 +0xa4
main.main()
        /Users/guyllian.gomez/dev/typescript-go/cmd/tsgo/main.go:10 +0x1c
```

## Test Plan
Build binary locally and test in API mode as well as with the binary powering tsserver in VS Code.