### PR TITLE
Fix alias resolution

### DIFF
--- a/internal/pnp/manifestparser.go
+++ b/internal/pnp/manifestparser.go
@@ -31,6 +31,14 @@ func (pd PackageDependency) IsAlias() bool {
 	return pd.AliasName != ""
 }
 
+func (pd PackageDependency) Locator() Locator {
+	name := pd.Ident
+	if pd.IsAlias() {
+		name = pd.AliasName
+	}
+	return Locator{Name: name, Reference: pd.Reference}
+}
+
 type PackageInfo struct {
 	PackageLocation     string              `json:"packageLocation"`
 	PackageDependencies []PackageDependency `json:"packageDependencies,omitempty"`
@@ -67,7 +75,7 @@ type PnpManifestData struct {
 	ignorePatternData      *regexp.Regexp
 	enableTopLevelFallback bool
 
-	fallbackPool         [][2]string
+	fallbackPool         []PackageDependency
 	fallbackExclusionMap map[string]*FallbackExclusion
 
 	dependencyTreeRoots []Locator
@@ -159,7 +167,7 @@ func parsePnpManifest(rawData map[string]any, manifestDir string) (*PnpManifestD
 
 	data.enableTopLevelFallback = getField(rawData, "enableTopLevelFallback", parseBool)
 
-	data.fallbackPool = getField(rawData, "fallbackPool", parseStringPairs)
+	data.fallbackPool = getField(rawData, "fallbackPool", parsePackageDependencies)
 
 	data.fallbackExclusionMap = make(map[string]*FallbackExclusion)
 
@@ -279,21 +287,6 @@ func parseStringArray(value any) []string {
 		return result
 	}
 	return nil
-}
-
-func parseStringPairs(value any) [][2]string {
-	var result [][2]string
-	if arr, ok := value.([]any); ok {
-		for _, item := range arr {
-			if pair, ok := item.([]any); ok && len(pair) == 2 {
-				result = append(result, [2]string{
-					parseString(pair[0]),
-					parseString(pair[1]),
-				})
-			}
-		}
-	}
-	return result
 }
 
 func parsePackageDependencies(value any) []PackageDependency {

--- a/internal/pnp/pnpapi.go
+++ b/internal/pnp/pnpapi.go
@@ -144,12 +144,8 @@ func (p *PnpApi) ResolveToUnqualified(specifier string, parentPath string) (stri
 		}
 	}
 
-	var dependencyPkg *PackageInfo
-	if referenceOrAlias.IsAlias() {
-		dependencyPkg = p.GetPackage(&Locator{Name: referenceOrAlias.AliasName, Reference: referenceOrAlias.Reference})
-	} else {
-		dependencyPkg = p.GetPackage(&Locator{Name: referenceOrAlias.Ident, Reference: referenceOrAlias.Reference})
-	}
+	dependencyLocator := referenceOrAlias.Locator()
+	dependencyPkg := p.GetPackage(&dependencyLocator)
 
 	return tspath.ResolvePath(p.manifest.dirPath, dependencyPkg.PackageLocation, modulePath), nil
 }
@@ -242,12 +238,8 @@ func (p *PnpApi) ResolveViaFallback(name string) *PackageDependency {
 	}
 
 	for _, dep := range p.manifest.fallbackPool {
-		if dep[0] == name {
-			return &PackageDependency{
-				Ident:     dep[0],
-				Reference: dep[1],
-				AliasName: "",
-			}
+		if dep.Ident == name {
+			return &dep
 		}
 	}
 
@@ -309,7 +301,8 @@ func (p *PnpApi) GetPnpTypeRoots(currentDirectory string) []string {
 	typeRoots := []string{}
 	for _, dep := range packageDependencies {
 		if strings.HasPrefix(dep.Ident, "@types/") && dep.Reference != "" {
-			packageInfo := p.GetPackage(&Locator{Name: dep.Ident, Reference: dep.Reference})
+			dependencyLocator := dep.Locator()
+			packageInfo := p.GetPackage(&dependencyLocator)
 			typeRoots = append(typeRoots, tspath.GetDirectoryPath(
 				tspath.ResolvePath(p.manifest.dirPath, packageInfo.PackageLocation),
 			))

--- a/internal/pnp/pnpapi_test.go
+++ b/internal/pnp/pnpapi_test.go
@@ -66,9 +66,6 @@ func TestResolveUnqualified(t *testing.T) {
 	}
 
 	for si := range suites {
-		if si != 0 {
-			continue
-		}
 		testSuite := &suites[si]
 
 		rawManifest := &testSuite.Manifest
@@ -100,41 +97,6 @@ func TestResolveUnqualified(t *testing.T) {
 				}
 			})
 		}
-	}
-}
-
-func TestResolveUnqualifiedFallbackAlias(t *testing.T) {
-	t.Parallel()
-	expectationsPath := filepath.Join(repo.TestDataPath(), "fixtures", "pnp", "test-expectations.json")
-
-	content, err := os.ReadFile(expectationsPath)
-	if err != nil {
-		t.Fatalf("Assertion failed: Expected the expectations to be found: %v", err)
-	}
-
-	var suites []TestSuite
-	if err = json.Unmarshal(content, &suites); err != nil {
-		t.Fatalf("Assertion failed: Expected the expectations to be loaded: %v", err)
-	}
-
-	if len(suites) < 2 {
-		t.Fatalf("Assertion failed: Expected fallback expectations to be present")
-	}
-
-	rawManifest := &suites[1].Manifest
-	manifest, err := parseManifestFromData(rawManifest.String(), "/path/to/project")
-	if err != nil {
-		t.Fatalf("failed to init pnp manifest: %v", err)
-	}
-
-	pnpApi := &PnpApi{fs: osvfs.FS(), url: "/path/to/project/.pnp.cjs", manifest: manifest}
-	res, unqualifiedErr := pnpApi.ResolveToUnqualified("alias", "/path/to/project/fooo")
-
-	if unqualifiedErr != nil {
-		t.Fatalf("expected fallback alias to resolve, got error: %v", unqualifiedErr.Message)
-	}
-	if res != "/path/to/project/test-1/" {
-		t.Fatalf("expected fallback alias to resolve to %q, got %q", "/path/to/project/test-1/", res)
 	}
 }
 

--- a/internal/pnp/pnpapi_test.go
+++ b/internal/pnp/pnpapi_test.go
@@ -103,6 +103,41 @@ func TestResolveUnqualified(t *testing.T) {
 	}
 }
 
+func TestResolveUnqualifiedFallbackAlias(t *testing.T) {
+	t.Parallel()
+	expectationsPath := filepath.Join(repo.TestDataPath(), "fixtures", "pnp", "test-expectations.json")
+
+	content, err := os.ReadFile(expectationsPath)
+	if err != nil {
+		t.Fatalf("Assertion failed: Expected the expectations to be found: %v", err)
+	}
+
+	var suites []TestSuite
+	if err = json.Unmarshal(content, &suites); err != nil {
+		t.Fatalf("Assertion failed: Expected the expectations to be loaded: %v", err)
+	}
+
+	if len(suites) < 2 {
+		t.Fatalf("Assertion failed: Expected fallback expectations to be present")
+	}
+
+	rawManifest := &suites[1].Manifest
+	manifest, err := parseManifestFromData(rawManifest.String(), "/path/to/project")
+	if err != nil {
+		t.Fatalf("failed to init pnp manifest: %v", err)
+	}
+
+	pnpApi := &PnpApi{fs: osvfs.FS(), url: "/path/to/project/.pnp.cjs", manifest: manifest}
+	res, unqualifiedErr := pnpApi.ResolveToUnqualified("alias", "/path/to/project/fooo")
+
+	if unqualifiedErr != nil {
+		t.Fatalf("expected fallback alias to resolve, got error: %v", unqualifiedErr.Message)
+	}
+	if res != "/path/to/project/test-1/" {
+		t.Fatalf("expected fallback alias to resolve to %q, got %q", "/path/to/project/test-1/", res)
+	}
+}
+
 func TestParseSinglePackageName(t *testing.T) {
 	t.Parallel()
 	pnpApi := &PnpApi{}


### PR DESCRIPTION
Fix Yarn PnP alias resolution for aliased fallback/dependency entries.

 can encode dependencies as aliases, for example:

```json
["relay-runtime", ["corp-relay-runtime", "npm:..."]]
```

In these cases, the requested dependency name is not always the package registry name. The resolver needs to look up the target package locator using the alias name plus reference, rather than the requested ident plus reference.

Changes
* Add PackageDependency.Locator() to centralize alias-aware locator construction.
* Parse fallbackPool entries as PackageDependency so fallback aliases are preserved.
* Use alias-aware locators when resolving:
  * normal dependencies
  * fallback dependencies
  * PnP type roots
