### PR TITLE
pnp: run all resolution test suites; fix the two bugs they surface

### DIFF
--- a/internal/module/resolver.go
+++ b/internal/module/resolver.go
@@ -1015,10 +1015,12 @@ func (r *resolutionState) loadModuleFromNearestNodeModulesDirectory(typesScopeOn
 }
 
 func (r *resolutionState) loadModuleFromNearestNodeModulesDirectoryWorker(ext extensions, mode core.ResolutionMode, typesScopeOnly bool) *resolved {
-	if r.resolver.host.PnpApi() != nil {
+	if pnpApi := r.resolver.host.PnpApi(); pnpApi != nil && !pnpApi.IsPathIgnored(r.containingDirectory) {
 		// !!! stop at global cache
 		return r.loadModuleFromImmediateNodeModulesDirectoryPnP(ext, r.containingDirectory, typesScopeOnly)
 	}
+	// A non-PnP project, or an importer covered by ignorePatternData: resolve
+	// through the classic ancestor node_modules walk below.
 
 	result, _ := tspath.ForEachAncestorDirectory(
 		r.containingDirectory,
@@ -1905,7 +1907,7 @@ func (r *resolutionState) readPackageJsonPeerDependencies(packageJsonInfo *packa
 	for _, name := range names {
 		var peerDependencyPath string
 
-		if pnpApi != nil {
+		if pnpApi != nil && !pnpApi.IsPathIgnored(packageDirectory) {
 			var err *pnp.PnpError
 			peerDependencyPath, err = pnpApi.ResolveToUnqualified(name, packageDirectory)
 			if err != nil {

--- a/internal/pnp/manifestparser.go
+++ b/internal/pnp/manifestparser.go
@@ -67,7 +67,7 @@ type PnpManifestData struct {
 	ignorePatternData      *regexp.Regexp
 	enableTopLevelFallback bool
 
-	fallbackPool         [][2]string
+	fallbackPool         []PackageDependency
 	fallbackExclusionMap map[string]*FallbackExclusion
 
 	dependencyTreeRoots []Locator
@@ -159,7 +159,10 @@ func parsePnpManifest(rawData map[string]any, manifestDir string) (*PnpManifestD
 
 	data.enableTopLevelFallback = getField(rawData, "enableTopLevelFallback", parseBool)
 
-	data.fallbackPool = getField(rawData, "fallbackPool", parseStringPairs)
+	// fallbackPool entries take the same shape as packageDependencies: a plain
+	// [name, reference] pair, or [name, [aliasName, reference]] for an alias. Parse
+	// it with the alias-aware parser so a pooled alias resolves to its target.
+	data.fallbackPool = getField(rawData, "fallbackPool", parsePackageDependencies)
 
 	data.fallbackExclusionMap = make(map[string]*FallbackExclusion)
 
@@ -279,21 +282,6 @@ func parseStringArray(value any) []string {
 		return result
 	}
 	return nil
-}
-
-func parseStringPairs(value any) [][2]string {
-	var result [][2]string
-	if arr, ok := value.([]any); ok {
-		for _, item := range arr {
-			if pair, ok := item.([]any); ok && len(pair) == 2 {
-				result = append(result, [2]string{
-					parseString(pair[0]),
-					parseString(pair[1]),
-				})
-			}
-		}
-	}
-	return result
 }
 
 func parsePackageDependencies(value any) []PackageDependency {

--- a/internal/pnp/pnpapi.go
+++ b/internal/pnp/pnpapi.go
@@ -87,6 +87,14 @@ func (p *PnpApi) ResolveToUnqualified(specifier string, parentPath string) (stri
 		return "", err
 	}
 
+	// An importer covered by ignorePatternData is not managed by PnP (e.g. a
+	// nested project with its own node_modules). Per the PnP spec, resolution
+	// falls back to the classic algorithm, so return the specifier unchanged for
+	// the caller to resolve conventionally.
+	if p.IsPathIgnored(parentPath) {
+		return specifier, nil
+	}
+
 	parentLocator, err := p.FindLocator(parentPath)
 	if err != nil || parentLocator == nil {
 		// Skipping resolution
@@ -188,21 +196,29 @@ func (p *PnpApi) GetPackage(locator *Locator) *PackageInfo {
 	return packageInfo
 }
 
+// IsPathIgnored reports whether path is covered by the manifest's
+// ignorePatternData, i.e. it is not managed by PnP and should resolve through the
+// classic algorithm.
+func (p *PnpApi) IsPathIgnored(path string) bool {
+	if p.manifest == nil || p.manifest.ignorePatternData == nil || path == "" {
+		return false
+	}
+	relativePath := tspath.GetRelativePathFromDirectory(p.manifest.dirPath, path,
+		tspath.ComparePathsOptions{UseCaseSensitiveFileNames: true})
+	return p.manifest.ignorePatternData.MatchString(relativePath)
+}
+
 func (p *PnpApi) FindLocator(parentPath string) (*Locator, *PnpError) {
 	if parentPath == "" {
 		return nil, nil
 	}
 
+	if p.IsPathIgnored(parentPath) {
+		return nil, nil
+	}
+
 	relativePath := tspath.GetRelativePathFromDirectory(p.manifest.dirPath, parentPath,
 		tspath.ComparePathsOptions{UseCaseSensitiveFileNames: true})
-
-	if p.manifest.ignorePatternData != nil {
-		match := p.manifest.ignorePatternData.MatchString(relativePath)
-
-		if match {
-			return nil, nil
-		}
-	}
 
 	var relativePathWithDot string
 	if strings.HasPrefix(relativePath, "../") {
@@ -249,12 +265,8 @@ func (p *PnpApi) ResolveViaFallback(name string) *PackageDependency {
 	}
 
 	for _, dep := range p.manifest.fallbackPool {
-		if dep[0] == name {
-			return &PackageDependency{
-				Ident:     dep[0],
-				Reference: dep[1],
-				AliasName: "",
-			}
+		if dep.Ident == name {
+			return &dep
 		}
 	}
 

--- a/internal/pnp/pnpapi_test.go
+++ b/internal/pnp/pnpapi_test.go
@@ -66,15 +66,12 @@ func TestResolveUnqualified(t *testing.T) {
 	}
 
 	for si := range suites {
-		if si != 0 {
-			continue
-		}
 		testSuite := &suites[si]
 
 		rawManifest := &testSuite.Manifest
 		manifest, err := parseManifestFromData(rawManifest.String(), "/path/to/project")
 		if err != nil {
-			t.Fatalf("failed to init pnp manifest: %v", err)
+			t.Fatalf("failed to init pnp manifest for suite %d: %v", si, err)
 		}
 
 		for _, tc := range testSuite.Tests {


### PR DESCRIPTION
Stacked on top of your Yarn PnP branch (microsoft/typescript-go#1966). Targets your branch so the diff is just these changes.

`TestResolveUnqualified` loads the full berry/esbuild `test-expectations.json` — **5 suites, ~18 cases** — but a `if si != 0 { continue }` in the suite loop runs **only the first suite**, so **11 of the imported cases never execute**: every fallback-pool, `fallbackExclusionList`, `ignorePatternData`, and global-package scenario.

Removing that one line surfaces **two real bugs** (both fixed here):

### 1. Fallback pool aliases

`fallbackPool` was parsed as `[][2]string`, which silently drops the `[name, [aliasName, reference]]` alias form Yarn emits — so a pooled alias never resolved (`should allow the fallback pool to contain aliases` failed). Parse it as `[]PackageDependency` with the existing alias-aware `parsePackageDependencies` (the same shape `packageDependencies` already use), and return the matched entry directly from `ResolveViaFallback`. The now-unused `parseStringPairs` is removed.

### 2. `ignorePatternData` importers

An importer covered by the ignore pattern is not managed by PnP (e.g. a nested project with its own `node_modules`). `ResolveToUnqualified` returned `""`, and — because the PnP path replaces the classic ancestor walk entirely — such imports could not resolve at all (`shouldn't go through PnP … covered by ignorePatternData` failed).

Fix, matching the [PnP spec](https://yarnpkg.com/advanced/pnp-spec)'s fallback-to-classic behavior:
- `ResolveToUnqualified` returns the specifier unchanged for an ignored importer (the spec's passthrough).
- `loadModuleFromNearestNodeModulesDirectoryWorker` runs the **classic ancestor `node_modules` walk** for an ignored importer instead of the PnP path.
- New `IsPathIgnored` helper, reused by `FindLocator` and guarding the peer-dependency resolution path (so an ignored package dir keeps its classic `node_modules + name` fallback).

## Result

All 5 suites (18 cases) pass. `internal/module` tests and the `pnp*` compiler baselines are unchanged. `gofmt` / `go vet` / the repo's `golangci-lint` are clean.

Context: this is the salvageable part of my own PnP attempt (microsoft/typescript-go#4568, now closed in favor of yours) — I hit the same design decisions you did and this is where I could actually add value. Happy to adjust anything to fit your direction, split it, or drop pieces.

---

*Disclosure: authored with Claude Code (agent-assisted); I've read and understood the changes and will respond to review, per microsoft/typescript-go's CONTRIBUTING AI-assistance policy.*
